### PR TITLE
pinning datasets version to fix finetuning

### DIFF
--- a/labs/FineTuning/HuggingFaceExample/01_finetuning/assets/requirements.txt
+++ b/labs/FineTuning/HuggingFaceExample/01_finetuning/assets/requirements.txt
@@ -2,3 +2,4 @@ optimum-neuron==0.0.27
 peft==0.14.0
 trl==0.11.4
 huggingface_hub==0.32.4
+datasets==3.6.0


### PR DESCRIPTION
Finetuning was failing with a strange error on the code we had not changed.
Something was updating datasets to 4.0.0.  We'll stick with the older version until datasets is fixed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
