### PR TITLE
Fix for DLAMI missing python library

### DIFF
--- a/labs/Lab_Two_NKI.ipynb
+++ b/labs/Lab_Two_NKI.ipynb
@@ -155,8 +155,8 @@
     "\n",
     "%pip install neuronx-cc==2.18.121.0+9e31e41a\n",
     "\n",
-    "%pip install torch torch_xla torch_neuronx\n"
-    "\n",
+    "%pip install torch torch_xla torch_neuronx\n",
+    "\n"
    ]
   },
   {

--- a/labs/Lab_Two_NKI.ipynb
+++ b/labs/Lab_Two_NKI.ipynb
@@ -150,9 +150,13 @@
    "source": [
     "### 3. Your second NKI kernel\n",
     "Now, let's try to use PyTorch arrays and pass them to the device with XLA. Then we'll try a matrix multiplication kernel.\n",
+    "\n",
     "If you get any errors, you may need to use a different python environment.  Choose the Python 3.9 kernel (or create a new venv) and install these packages:\n",
-    "%pip install neuronx-cc==2.18.121.0+9e31e41a",
-    "%pip install torch torch_xla torch_neuronx"
+    "\n",
+    "%pip install neuronx-cc==2.18.121.0+9e31e41a\n",
+    "\n",
+    "%pip install torch torch_xla torch_neuronx\n"
+    "\n",
    ]
   },
   {

--- a/labs/Lab_Two_NKI.ipynb
+++ b/labs/Lab_Two_NKI.ipynb
@@ -149,7 +149,10 @@
    "metadata": {},
    "source": [
     "### 3. Your second NKI kernel\n",
-    "Now, let's try to use PyTorch arrays and pass them to the device with XLA. Then we'll try a matrix multiplication kernel."
+    "Now, let's try to use PyTorch arrays and pass them to the device with XLA. Then we'll try a matrix multiplication kernel.\n",
+    "If you get any errors, you may need to use a different python environment.  Choose the Python 3.9 kernel (or create a new venv) and install these packages:\n",
+    "%pip install neuronx-cc==2.18.121.0+9e31e41a",
+    "%pip install torch torch_xla torch_neuronx"
    ]
   },
   {


### PR DESCRIPTION
Issues reported elsewhere that the second example in the NKI lab was failing because the latest DLAMI has a missing python library file.
*Description of changes:*
Added a note in the text of the NKI lab telling users what to do if they have a failure.  I kept everything in the comments, so no code changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
